### PR TITLE
refactor: limit scope of doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ A curated list of great books for people who manage engineering teams. Pull requ
 
 ## Table of Contents
 
-### [Soft Skills](#soft-skills)
+### Part I: [Soft Skills](#soft-skills)
 ---
-* [Management](#management)  
-* [Leadership](#leadership)    
-* [People](#people)  
-* [Culture](#culture)  
-* [Change Management](#change-management)   
-* [Agile Methodologies](#agile-methodologies)   
-* [Public Speaking](#public-speaking)
+1. [Management](#management)  
+1. [Leadership](#leadership)    
+1. [People](#people)  
+1. [Culture](#culture)  
+1. [Change Management](#change-management)   
+1. [Agile Methodologies](#agile-methodologies)   
+1. [Public Speaking](#public-speaking)
 
-### [Tech Skills](#tech-skills)
+### Part II: [Tech Skills](#tech-skills)
 ---
-* [Software Engineering](#software-engineering)  
-* [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
-* [Testing](#testing)   
+1. [Software Engineering](#software-engineering)  
+1. [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
+1. [Testing](#testing)   
 
 ## Soft Skills
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ A curated list of great books for people who manage engineering teams. Pull requ
 1. [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
 1. [Testing](#testing)   
 
-## Soft Skills
+## Books
 
-### Management
+### Soft Skills
+
+#### Management
 
 [Building Great Software Engineering Teams](https://www.amazon.com/Building-Great-Software-Engineering-Teams/dp/1484211340) by Joshua Tyler  
 [Death by Meeting](https://www.amazon.com/Death-Meeting-Leadership-Solving-Business/dp/0787968056) by Patrick M. Lencioni  
@@ -40,7 +42,7 @@ A curated list of great books for people who manage engineering teams. Pull requ
 [Managing the Unmanageable: Rules, Tools, and Insights for Managing Software People and Teams](https://www.amazon.com/dp/032182203X) by Mickey W. Mantle and Ron Lichty  
 [Behind Closed Doors: Secrets of Great Management](https://www.amazon.com/Behind-Closed-Doors-Management-Programmers/dp/0976694026) by Johanna Rothman and Esther Derby
 
-### Leadership
+#### Leadership
 
 [Leading Snowflakes](http://leadingsnowflakes.com/) by Oren Ellenbogen  
 [The Score Takes Care of Itself](https://www.amazon.com/Score-Takes-Care-Itself-Philosophy/dp/1591843472) by Bill Walsh, Steve Jamison, and Craig Walsh  
@@ -49,13 +51,13 @@ A curated list of great books for people who manage engineering teams. Pull requ
 [Nonviolent Communication: A Language of Life](https://www.amazon.com/Nonviolent-Communication-Language-Life-Changing-Relationships/dp/189200528X) by Marshall B. Rosenberg PhD  
 [Developing the Leader Within You](https://www.amazon.com/Developing-Leader-Within-John-Maxwell/dp/0785281126) by John C. Maxwell  
 
-### People
+#### People
 
 [Peopleware](https://www.amazon.com/Peopleware-Productive-Projects-Teams-3rd/dp/0321934113/ref=dp_ob_title_bk) by Tom DeMarco and Tim Lister  
 [The Mythical Man-Month](https://www.amazon.com/Mythical-Man-Month-Software-Engineering-Anniversary/dp/0201835959/) by Frederick P. Brooks Jr.  
 [How to Win Friends and Influence People](https://www.amazon.com/How-Win-Friends-Influence-People/dp/0671027034) by Dale Carnegie  
 
-### Culture
+#### Culture
 
 [It Doesn't Have to Be Crazy at Work](https://www.amazon.com/gp/product/0062874780/ref=dbs_a_def_rwt_bibl_vppi_i0) by Jason Fried and David Heinemeier Hansson  
 [The Hard Thing About Hard Things](https://www.amazon.com/dp/B00DQ845EA) by Ben Horowitz  
@@ -69,23 +71,25 @@ A curated list of great books for people who manage engineering teams. Pull requ
 [The Five Dysfunctions of a Team](https://www.amazon.com/Five-Dysfunctions-Team-Leadership-Fable/dp/0787960756) by Patrick Lencioni  
 [Brotopia](https://www.amazon.com/Brotopia-Breaking-Boys-Silicon-Valley/dp/0735213534) by Emily Chang  
 
-### Change Management
+#### Change Management
+
 [Change or Die: The Three Keys to Change at Work and in Life](https://www.amazon.com/Change-Die-Three-Keys-Work/dp/B000MV8X3I/) by Alan Deutschman  
 [Switch: How to Change Things When Change Is Hard](https://www.amazon.com/Switch-Change-Things-When-Hard/dp/B0038NLX9S/) by Dan Heath, Chip Heath, Charles Kahlenberg  
 [HBR's 10 Must Reads on Change Management](https://www.amazon.com/Change-Management-including-featured-Leading/dp/1422158004) by John P. Kotter, W. Chan Kim, Renée A. Mauborgne  
 
-### Agile Methodologies
+#### Agile Methodologies
+
 [Scrum: The Art of Doing Twice the Work in Half the Time](https://www.amazon.com/Scrum-Doing-Twice-Work-Half/dp/038534645X) by Jeff Sutherland and JJ Sutherland  
 [Essential Scrum: A Practical Guide to the Most Popular Agile Process](https://www.amazon.com/Essential-Scrum-Practical-Addison-Wesley-Signature/dp/0137043295) by Kenneth S. Rubin  
 [Agile Retrospectives: Making Good Teams Great](https://www.amazon.com/dp/B00B03SRJW/) by Esther Derby, Diana Larsen, and Ken Schwaber  
 
-### Public Speaking
+#### Public Speaking
 
 [Demystifying Public Speaking](https://alistapart.com/article/demystifying-public-speaking) by Lara Hogan  
 
-## Tech Skills
+### Tech Skills
 
-### Software Engineering
+#### Software Engineering
 
 [The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X) by Andrew Hunt and David Thomas  
 [The Effective Engineer](https://www.theeffectiveengineer.com/book) by Edmond Lau  
@@ -93,11 +97,11 @@ A curated list of great books for people who manage engineering teams. Pull requ
 [Software Estimation: Demystifying the Black Art](https://www.amazon.com/Software-Estimation-Demystifying-Developer-Practices/dp/0735605351) by Steve McConnell  
 [Software Project Survival Guide](https://www.amazon.com/dp/1572316217) by Steve McConnell  
 
-### Continuous Delivery / Continuous Integration
+#### Continuous Delivery / Continuous Integration
 
 [Continuous Delivery](https://www.amazon.com/Continuous-Delivery-Deployment-Automation-Addison-Wesley/dp/0321601912) by Jez Humble and David Farley  
 [Continuous Integration: Improving Software Quality and Reducing Risk](https://www.amazon.com/gp/product/0321336380) by Paul M. Duvall, Steve Matyas, and Andrew Glover  
 
-### Testing
+#### Testing
 
 [Test Driven Development](https://www.amazon.com/Test-Driven-Development-Kent-Beck/dp/0321146530) by Kent Beck  

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ A curated list of great books for people who manage engineering teams. Pull requ
 ## Table of Contents
 
 ### [Soft Skills](#soft-skills)
-  [Management](#management)  
-  [Leadership](#leadership)    
-  [People](#people)  
-  [Culture](#culture)  
-  [Change Management](#change-management)   
-  [Agile Methodologies](#agile-methodologies)   
-  [Public Speaking](#public-speaking)
+---
+* [Management](#management)  
+* [Leadership](#leadership)    
+* [People](#people)  
+* [Culture](#culture)  
+* [Change Management](#change-management)   
+* [Agile Methodologies](#agile-methodologies)   
+* [Public Speaking](#public-speaking)
 
 ### [Tech Skills](#tech-skills)
-  [Software Engineering](#software-engineering)  
-  [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
-  [Testing](#testing)   
+---
+* [Software Engineering](#software-engineering)  
+* [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
+* [Testing](#testing)   
 
 ## Soft Skills
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ A curated list of great books for people who manage engineering teams. Pull requ
 
 ## Table of Contents
 
-[Soft Skills](#soft-skills)
-1. [Management](#management)  
-1. [Leadership](#leadership)    
-1. [People](#people)  
-1. [Culture](#culture)  
-1. [Change Management](#change-management)   
-1. [Agile Methodologies](#agile-methodologies)   
-1. [Public Speaking](#public-speaking)
+### [Soft Skills](#soft-skills)
+  [Management](#management)  
+  [Leadership](#leadership)    
+  [People](#people)  
+  [Culture](#culture)  
+  [Change Management](#change-management)   
+  [Agile Methodologies](#agile-methodologies)   
+  [Public Speaking](#public-speaking)
 
-[Tech Skills](#tech-skills)
-1. [Software Engineering](#articles)  
-1. [Continuous Delivery / Continuous Integration](#continuous-delivery-/-continuous-integration)  
-1. [Testing](#testing)   
+### [Tech Skills](#tech-skills)
+  [Software Engineering](#software-engineering)  
+  [Continuous Delivery / Continuous Integration](#continuous-delivery--continuous-integration)  
+  [Testing](#testing)   
 
 ## Soft Skills
 

--- a/README.md
+++ b/README.md
@@ -1,146 +1,25 @@
 
-# Awesome Engineering Manager's Handbook [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# The Engineering Manager's Booklist
 
-A curated list of great resources made for people who manage engineering teams. Pull requests are welcome.
+A curated list of great books for people who manage engineering teams. Pull requests are welcome.
 
 ## Table of Contents
 
-1. [Articles](#articles)  
-1. [Newsletters](#newsletters)  
-1. [Books](#books)  
-1. [Tools](#tools)  
-1. [Videos](#videos)  
+[Soft Skills](#soft-skills)
+1. [Management](#management)  
+1. [Leadership](#leadership)    
+1. [People](#people)  
+1. [Culture](#culture)  
+1. [Change Management](#change-management)   
+1. [Agile Methodologies](#agile-methodologies)   
+1. [Public Speaking](#public-speaking)
 
-## Articles
+[Tech Skills](#tech-skills)
+1. [Software Engineering](#articles)  
+1. [Continuous Delivery / Continuous Integration](#continuous-delivery-/-continuous-integration)  
+1. [Testing](#testing)   
 
-### General
-
-[Google's Manager Resources Website](https://rework.withgoogle.com/subjects/managers/) from Google  
-[Six Recipes for Software Managers](http://eng.localytics.com/six-recipes-for-software-managers/) from Localytics  
-[8 Key Tactics For Developing Employees](https://www.forbes.com/sites/steveolenski/2015/07/20/8-key-tactics-for-developing-employees/#403567a66373) from Forbes  
-[The 6 Surprising Questions that Ensure the Effectiveness of Google Management](https://getlighthouse.com/blog/google-management/) from Lighthouse  
-[10 Key Andy Grove Quotes on Leadership from High Output Management](https://getlighthouse.com/blog/andy-grove-quotes-leadership-high-output-management) from Lighthouse  
-[How do managers get stuck?](http://www.elidedbranches.com/2017/09/how-do-managers-get-stuck.html) from Elided Branches  
-
-### Performance
-
-[Assessing Employee Performance](https://medium.com/javascript-scene/assessing-employee-performance-1a8bdee45c1a) from Eric Elliot
-
-### Leadership
-
-[Effective Technical Leadership](https://medium.com/always-be-coding/effective-technical-leadership-b193a544e771) from David Byttow  
-[5 Tips for Being an Effective Tech Lead](https://www.thoughtworks.com/insights/blog/5-tips-being-effective-tech-lead) from Thoughtworks  
-[Three Powerful Conversations Managers Must Have To Develop Their People](http://firstround.com/review/three-powerful-conversations-managers-must-have-to-develop-their-people/) from First Round  
-[Scaling your software becomes increasingly easier, but what about scaling your team?](https://medium.com/@orenellenbogen/scaling-your-software-becomes-increasingly-easier-but-what-about-scaling-your-team-f8ab8e0da20f#.3t23ki1ao) from Oren Ellenbogen  
-[The Best Leaders Are Humble Leaders](https://hbr.org/2014/05/the-best-leaders-are-humble-leaders) from Harvard Business Review  
-
-### 1:1s
-
-[Why 1-1 meetings are crucial to your team’s success](https://blog.asana.com/2015/05/workstyle-what-is-a-1-1/) from Asana  
-[One on One](http://www.bhorowitz.com/one_on_one) from Ben Horowitz  
-[Master the One-on-One Meeting](http://hbswk.hbs.edu/item/master-the-one-on-one-meeting) from Harvard  
-[How to Make Your One-on-Ones with Employees More Productive](https://hbr.org/2016/08/how-to-make-your-one-on-ones-with-employees-more-productive) from Harvard  
-[A 101 on 1:1s](https://labs.spotify.com/2015/12/16/a-101-on-11s/) from Spotify  
-[Conducting Effective and Regular One-on-Ones](https://moz.com/blog/conducting-effective-and-regular-oneonones) from Moz  
-[The Art of the Awkward 1:1](https://medium.com/@mrabkin/the-art-of-the-awkward-1-1-f4e1dcbd1c5c) from Mark Rabkin  
-[7 Essential Tips for Effective 1 on 1 Meetings with Your Manager](https://getlighthouse.com/blog/effective-1-on-1-meetings) from Lighthouse  
-[How to have an honest one-on-one with an employee](https://m.signalvnoise.com/how-to-have-an-honest-one-on-one-with-an-employee-24bbddeb0f47#.pwsmwxjnb) from Signal vs Noise  
-[How to Have Effective 1:1s](https://www.radicalcandor.com/blog/effective-one-on-ones/) from Radical Candor  
-
-### Teamwork
-
-[Guilds: Get Stuff Done Together](http://code.hootsuite.com/guilds/) from Hootsuite  
-[The Essential Guide to Building Balanced Development Teams](https://medium.com/javascript-scene/the-essential-guide-to-building-balanced-development-teams-b051a62acc80) from Eric Elliott  
-[How to Build a High Velocity Development Team](https://medium.com/javascript-scene/how-to-build-a-high-velocity-development-team-4b2360d34021) from Eric Elliott  
-
-### Productivity
-
-[How to Grow from Being Average to a 10x Engineer](http://www.theeffectiveengineer.com/blog/how-to-become-a-10x-engineer) from The Effective Engineer  
-
-### Culture
-
-[The Buffer Culture](http://www.slideshare.net/Bufferapp/buffer-culture-03) from Buffer  
-[Culture Code: Creating A Lovable Company](http://www.slideshare.net/HubSpot/the-hubspot-culture-code-creating-a-company-we-love) from HubSpot  
-[Optimizing for Happiness](https://speakerdeck.com/mojombo/optimizing-for-happiness) from GitHub  
-[What Makes a Good Engineering Culture](http://www.theeffectiveengineer.com/blog/what-makes-a-good-engineering-culture) from The Effective Engineer  
-[What Google Learned From Its Quest to Build the Perfect Team](http://www.nytimes.com/2016/02/28/magazine/what-google-learned-from-its-quest-to-build-the-perfect-team.html) from New York Times  
-[Why psychological safety matters and what to do about it](https://rework.withgoogle.com/blog/how-to-foster-psychological-safety/) from Google  
-[Building and Motivating Engineering Teams](https://medium.com/swlh/building-and-motivating-engineering-teams-24fd56910039) from The Startup  
-[What Companies Get Wrong About Motivating Their People](https://www.washingtonpost.com/news/on-leadership/wp/2016/11/25/what-companies-get-wrong-about-motivating-their-people/?utm_term=.c5af3f18cf2c) from Washington  
-[What Great Managers Do Daily](https://hbr.org/2016/12/what-great-managers-do-daily) from Harvard Business Review  
-
-### Blogging
-
-[Yes, your team should be blogging](http://michaelrbernste.in/2016/11/02/blog-blog-blog.html) from Michael Robert Bernstein  
-
-### Goal Setting
-
-[About predictability and clearly defining team goals](http://ourbit.norbertoherz.com//2016/11/01/about-predictability-and-team-goals/) from Norberto L. Herz  
-
-### Meetings
-
-[A Field Guide to Dudes Who Ruin Meetings](https://medium.com/part-and-sum/a-field-guide-to-dudes-who-ruin-meetings-3877de28b661#.di6epdtpw) from Jim Babb  
-
-### Interviewing  
-
-[How to Interview Engineers](http://blog.triplebyte.com/how-to-interview-engineers)  
-
-**[⬆ back to top](#table-of-contents)**
-
-## Newsletters
-
-### Leadership
-
-[On Engineering Leadership](https://tinyletter.com/jesselpalmer) This is mine 😊  
-[Leading Software People](https://leadingsoftwarepeople.statushero.com/)  
-[Software Lead Weekly](http://softwareleadweekly.com/)  
-[Tech Leadership Weekly](http://www.techleadershipweekly.com/)  
-[Engineering Impact](https://www.gitprime.com/engineering-impact/)  
-
-### Software Engineering
-
-[The Effective Engineer](http://www.theeffectiveengineer.com/)  
-
-**[⬆ back to top](#table-of-contents)**
-
-## Books
-
-### Software Engineering
-
-[The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X) by Andrew Hunt and David Thomas  
-[The Effective Engineer](https://www.theeffectiveengineer.com/book) by Edmond Lau  
-[Rapid Development](https://www.amazon.com/Rapid-Development-Taming-Software-Schedules/dp/1556159005) by Steve McConnell  
-[Software Estimation: Demystifying the Black Art](https://www.amazon.com/Software-Estimation-Demystifying-Developer-Practices/dp/0735605351) by Steve McConnell  
-[Software Project Survival Guide](https://www.amazon.com/dp/1572316217) by Steve McConnell  
-
-### Continuous Delivery / Continuous Integration
-
-[Continuous Delivery](https://www.amazon.com/Continuous-Delivery-Deployment-Automation-Addison-Wesley/dp/0321601912) by Jez Humble and David Farley  
-[Continuous Integration: Improving Software Quality and Reducing Risk](https://www.amazon.com/gp/product/0321336380) by Paul M. Duvall, Steve Matyas, and Andrew Glover  
-
-### Testing
-
-[Test Driven Development](https://www.amazon.com/Test-Driven-Development-Kent-Beck/dp/0321146530) by Kent Beck  
-
-### People
-
-[Peopleware](https://www.amazon.com/Peopleware-Productive-Projects-Teams-3rd/dp/0321934113/ref=dp_ob_title_bk) by Tom DeMarco and Tim Lister  
-[The Mythical Man-Month](https://www.amazon.com/Mythical-Man-Month-Software-Engineering-Anniversary/dp/0201835959/) by Frederick P. Brooks Jr.  
-[How to Win Friends and Influence People](https://www.amazon.com/How-Win-Friends-Influence-People/dp/0671027034) by Dale Carnegie  
-
-### Culture
-
-[It Doesn't Have to Be Crazy at Work](https://www.amazon.com/gp/product/0062874780/ref=dbs_a_def_rwt_bibl_vppi_i0) by Jason Fried and David Heinemeier Hansson  
-[The Hard Thing About Hard Things](https://www.amazon.com/dp/B00DQ845EA) by Ben Horowitz  
-[Good to Great](https://www.amazon.com/Good-Great-Some-Companies-Others-ebook/dp/B0058DRUV6) by Jim Collins  
-[How Google Works](https://www.amazon.com/How-Google-Works/dp/B00MOZPSYW) by Eric Schmidt, Jonathan Rosenberg and Alan Eagle  
-[Rework](https://www.amazon.com/Rework-Jason-Fried-ebook/dp/B002MUAJ2A) by Jason Fried and David Heinemeier Hansson  
-[DevOps Handbook](https://www.amazon.com/DevOps-Handbook-World-Class-Reliability-Organizations/dp/1942788002) by Gene Kim, Patrick Debois, John Willis and Jez Humble  
-[The Phoenix Project](https://www.amazon.com/Phoenix-Project-DevOps-Helping-Business-ebook/dp/B00AZRBLHO) by Gene Kim, Kevin Behr and George Spafford  
-[Optimizing For Happiness](https://speakerdeck.com/mojombo/optimizing-for-happiness) by Tom Preston-Werner  
-[Slack: Getting Past Burnout, Busywork, and the Myth of Total Efficiency](https://www.amazon.com/Slack-Getting-Burnout-Busywork-Efficiency/dp/0767907698) by Tom DeMarco  
-[The Five Dysfunctions of a Team](https://www.amazon.com/Five-Dysfunctions-Team-Leadership-Fable/dp/0787960756) by Patrick Lencioni  
-[Brotopia](https://www.amazon.com/Brotopia-Breaking-Boys-Silicon-Valley/dp/0735213534) by Emily Chang  
+## Soft Skills
 
 ### Management
 
@@ -168,6 +47,26 @@ A curated list of great resources made for people who manage engineering teams. 
 [Nonviolent Communication: A Language of Life](https://www.amazon.com/Nonviolent-Communication-Language-Life-Changing-Relationships/dp/189200528X) by Marshall B. Rosenberg PhD  
 [Developing the Leader Within You](https://www.amazon.com/Developing-Leader-Within-John-Maxwell/dp/0785281126) by John C. Maxwell  
 
+### People
+
+[Peopleware](https://www.amazon.com/Peopleware-Productive-Projects-Teams-3rd/dp/0321934113/ref=dp_ob_title_bk) by Tom DeMarco and Tim Lister  
+[The Mythical Man-Month](https://www.amazon.com/Mythical-Man-Month-Software-Engineering-Anniversary/dp/0201835959/) by Frederick P. Brooks Jr.  
+[How to Win Friends and Influence People](https://www.amazon.com/How-Win-Friends-Influence-People/dp/0671027034) by Dale Carnegie  
+
+### Culture
+
+[It Doesn't Have to Be Crazy at Work](https://www.amazon.com/gp/product/0062874780/ref=dbs_a_def_rwt_bibl_vppi_i0) by Jason Fried and David Heinemeier Hansson  
+[The Hard Thing About Hard Things](https://www.amazon.com/dp/B00DQ845EA) by Ben Horowitz  
+[Good to Great](https://www.amazon.com/Good-Great-Some-Companies-Others-ebook/dp/B0058DRUV6) by Jim Collins  
+[How Google Works](https://www.amazon.com/How-Google-Works/dp/B00MOZPSYW) by Eric Schmidt, Jonathan Rosenberg and Alan Eagle  
+[Rework](https://www.amazon.com/Rework-Jason-Fried-ebook/dp/B002MUAJ2A) by Jason Fried and David Heinemeier Hansson  
+[DevOps Handbook](https://www.amazon.com/DevOps-Handbook-World-Class-Reliability-Organizations/dp/1942788002) by Gene Kim, Patrick Debois, John Willis and Jez Humble  
+[The Phoenix Project](https://www.amazon.com/Phoenix-Project-DevOps-Helping-Business-ebook/dp/B00AZRBLHO) by Gene Kim, Kevin Behr and George Spafford  
+[Optimizing For Happiness](https://speakerdeck.com/mojombo/optimizing-for-happiness) by Tom Preston-Werner  
+[Slack: Getting Past Burnout, Busywork, and the Myth of Total Efficiency](https://www.amazon.com/Slack-Getting-Burnout-Busywork-Efficiency/dp/0767907698) by Tom DeMarco  
+[The Five Dysfunctions of a Team](https://www.amazon.com/Five-Dysfunctions-Team-Leadership-Fable/dp/0787960756) by Patrick Lencioni  
+[Brotopia](https://www.amazon.com/Brotopia-Breaking-Boys-Silicon-Valley/dp/0735213534) by Emily Chang  
+
 ### Change Management
 [Change or Die: The Three Keys to Change at Work and in Life](https://www.amazon.com/Change-Die-Three-Keys-Work/dp/B000MV8X3I/) by Alan Deutschman  
 [Switch: How to Change Things When Change Is Hard](https://www.amazon.com/Switch-Change-Things-When-Hard/dp/B0038NLX9S/) by Dan Heath, Chip Heath, Charles Kahlenberg  
@@ -182,42 +81,21 @@ A curated list of great resources made for people who manage engineering teams. 
 
 [Demystifying Public Speaking](https://alistapart.com/article/demystifying-public-speaking) by Lara Hogan  
 
-**[⬆ back to top](#table-of-contents)**
+## Tech Skills
 
-## Tools
+### Software Engineering
 
-### Team Surveys
+[The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X) by Andrew Hunt and David Thomas  
+[The Effective Engineer](https://www.theeffectiveengineer.com/book) by Edmond Lau  
+[Rapid Development](https://www.amazon.com/Rapid-Development-Taming-Software-Schedules/dp/1556159005) by Steve McConnell  
+[Software Estimation: Demystifying the Black Art](https://www.amazon.com/Software-Estimation-Demystifying-Developer-Practices/dp/0735605351) by Steve McConnell  
+[Software Project Survival Guide](https://www.amazon.com/dp/1572316217) by Steve McConnell  
 
-[15Five](https://www.15five.com/)  
-[TINYPulse](https://www.tinypulse.com/)  
-[Google Forms](https://www.google.com/forms/about/)  
+### Continuous Delivery / Continuous Integration
 
-#### Project Management
+[Continuous Delivery](https://www.amazon.com/Continuous-Delivery-Deployment-Automation-Addison-Wesley/dp/0321601912) by Jez Humble and David Farley  
+[Continuous Integration: Improving Software Quality and Reducing Risk](https://www.amazon.com/gp/product/0321336380) by Paul M. Duvall, Steve Matyas, and Andrew Glover  
 
-[Jira](https://jira.com/)  
-[Trello](https://trello.com/)  
-[Asana](https://asana.com)  
-[GitHub Project Boards](https://help.github.com/articles/about-project-boards/)
+### Testing
 
-### Personal Productivity
-
-#### Mindfulness
-
-[Headspace](https://www.headspace.com/)  
-[Calm](https://www.calm.com/)  
-
-#### Journal
-
-[BestSelf](https://bestself.co/products/self-journal)  
-[5 Minute Journal](https://www.intelligentchange.com/products/the-five-minute-journal)  
-
-**[⬆ back to top](#table-of-contents)**
-
-## Videos
-
-### Leadership
-
-[Using Agile Techniques to Build a More Inclusive Team](https://www.youtube.com/watch?v=Atfxtk2Q90k) by Kevin Goldsmith at LeadDevLondon 2018  
-[Decode the Career Path to VP of Engineering](https://www.youtube.com/watch?v=nELJ8pDpjYw)
-
-**[⬆ back to top](#table-of-contents)**
+[Test Driven Development](https://www.amazon.com/Test-Driven-Development-Kent-Beck/dp/0321146530) by Kent Beck  

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A curated list of great resources made for people who manage engineering teams. 
 [Principles of Software Engineering Management](https://www.amazon.com/Principles-Software-Engineering-Management-Gilb/dp/0201192462) by Tom Glib  
 [The Goal: A Process of Ongoing Improvement](https://www.amazon.com/Goal-Process-Ongoing-Improvement/dp/0884270610) by Eliyahu M. Goldratt and Jeff Cox  
 [Managing the Unmanageable: Rules, Tools, and Insights for Managing Software People and Teams](https://www.amazon.com/dp/032182203X) by Mickey W. Mantle and Ron Lichty  
+[Behind Closed Doors: Secrets of Great Management](https://www.amazon.com/Behind-Closed-Doors-Management-Programmers/dp/0976694026) by Johanna Rothman and Esther Derby
 
 ### Leadership
 


### PR DESCRIPTION
In an effort to focus on the most useful part of the Handbook, I changed the scope of the README to be only books. This list seems to have become too broad and to me when things become too broad then effectiveness is lost. By focusing on the most important part of the list, I believe this doc will be more effective and useful to people.